### PR TITLE
Add client for Schibsted SSO

### DIFF
--- a/podme_api/__init__.py
+++ b/podme_api/__init__.py
@@ -4,4 +4,4 @@ import pkg_resources  # part of setuptools
 
 __version__ = pkg_resources.get_distribution("podme_api").version
 
-from podme_api.client import PodMeClient
+from podme_api.client import PodMeClient, PodMeSchibstedClient

--- a/podme_api/const.py
+++ b/podme_api/const.py
@@ -1,7 +1,8 @@
 """ """
 
-PODME_API_URL = "https://api.podme.com/web/api/v2{endpoint}"
 PODME_AUTH_USER_AGENT = 'Mozilla/5.0 (X11; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0'
+
+PODME_API_URL = "https://api.podme.com/web/api/v2{endpoint}"
 PODME_AUTH_CLIENT_ID = "6e1a23e7-71ec-4483-918a-25c33852c9c9"
 PODME_AUTH_TENANT = "reacthello"
 PODME_AUTH_LOGIN_USER_FLOW = "B2C_1_web_combined_login"
@@ -11,3 +12,17 @@ PODME_AUTH_TOKEN_URL = "https://{tenant}.b2clogin.com/{tenant}.onmicrosoft.com/{
     login_user_flow=PODME_AUTH_LOGIN_USER_FLOW,
 )
 PODME_AUTH_REDIRECT_URI = "https://podme.com/static/redirect.html"
+
+PODME_SCHIBSTED_AUTH_DOMAIN = "https://payment.schibsted.no"
+PODME_SCHIBSTED_AUTH_URL_BASE = f"{PODME_SCHIBSTED_AUTH_DOMAIN}/oauth/authorize"
+PODME_SCHIBSTED_AUTH_CLIENT_ID = "626bcf5e1332f10a4997c29a"
+PODME_SCHIBSTED_AUTH_REDIRECT = "https://podme.com/auth/handleSchibstedLogin"
+PODME_SCHIBSTED_AUTH_RETURN_URL = "https://podme.com/no/oppdag"
+PODME_SCHIBSTED_AUTH_SCOPE = "openid+email"
+PODME_SCHIBSTED_AUTH_RESPONSE_TYPE = "code"
+PODME_SCHIBSTED_AUTH_CSRF_URL = f"{PODME_SCHIBSTED_AUTH_DOMAIN}/authn/api/settings/csrf?" \
+                                f"client_id={PODME_SCHIBSTED_AUTH_CLIENT_ID}"
+PODME_SCHIBSTED_AUTH_LOGIN_URL = f"{PODME_SCHIBSTED_AUTH_DOMAIN}/authn/api/identity/login/?" \
+                                 f"client_id={PODME_SCHIBSTED_AUTH_CLIENT_ID}"
+PODME_SCHIBSTED_AUTH_FINISH_URL = f"{PODME_SCHIBSTED_AUTH_DOMAIN}/authn/identity/finish/?" \
+                                  f"client_id={PODME_SCHIBSTED_AUTH_CLIENT_ID}"


### PR DESCRIPTION
Addresses #1 

Initial attempt at supporting Schibsted login via the PodMe client. 

- Defined `PodMeSchibstedClient` as a subclass of the original `PodMeClient`, where most of the logic is the same but with the appropriate token retrieval implementation. 

- The client currently only supports the `NO` region (Norway), but supporting other regions might just be a matter of adding some more endpoints and redirect urls. This needs some more research though.

- The implementation has not been thoroughly tested, but at least episode retrieval/download and token refreshing seems to work as expected (also tested with [pasjonsfrukt](https://github.com/mathiazom/pasjonsfrukt/tree/schibsted-auth)). Token retrieval is based on DevTools observations, so things could definitely break...